### PR TITLE
support tagging saved requests

### DIFF
--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -46,6 +46,7 @@ export const requestsTableSchema = z.object({
   created_at: z.date(),
   control: controlDataSchema,
   shadows: z.array(shadowDataSchema),
+  tags: z.record(z.string(), z.string()).nullable(),
   replays: z
     .array(
       z.object({
@@ -54,7 +55,7 @@ export const requestsTableSchema = z.object({
         divergent: z.boolean(),
         control: controlDataSchema,
         shadows: z.array(shadowDataSchema),
-      })
+      }),
     )
     .nullable(),
 });

--- a/shadower/src/worker.ts
+++ b/shadower/src/worker.ts
@@ -15,6 +15,7 @@ type ShadowingTarget = {
   timeout: number;
   statuses?: number[];
   sampleRate: number;
+  tags?: Record<string, string>;
 };
 
 // https://datatracker.ietf.org/doc/html/rfc6902#section-3
@@ -85,6 +86,7 @@ const getConfig = (url: URL): ShadowingConfig | undefined => {
           timeout: 5,
           statuses: [200],
           sampleRate: 1.0,
+          tags: { example: "oh-yeah" },
         },
       ],
     };
@@ -266,8 +268,13 @@ const shadow = async (
     );
   } else {
     await client.query(
-      "INSERT INTO requests (id, divergent, control, shadows) VALUES (gen_random_uuid(), $1, $2, $3);",
-      [divergent, JSON.stringify(controlData), JSON.stringify([shadowData])],
+      "INSERT INTO requests (id, divergent, control, shadows, tags) VALUES (gen_random_uuid(), $1, $2, $3, $4);",
+      [
+        divergent,
+        JSON.stringify(controlData),
+        JSON.stringify([shadowData]),
+        JSON.stringify(config.targets[0].tags),
+      ],
     );
   }
 

--- a/tables.sql
+++ b/tables.sql
@@ -4,5 +4,6 @@ CREATE TABLE requests(
 	control jsonb,
 	shadows jsonb,
 	replays jsonb,
+    tags jsonb,
 	created_at timestamp DEFAULT NOW()
 );

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,2 @@
+public/
+functions/

--- a/web/.prettierrc.yaml
+++ b/web/.prettierrc.yaml
@@ -1,0 +1,3 @@
+useTabs: false
+singleQuote: true
+trailingComma: all

--- a/web/app/routes/mirrors/route.tsx
+++ b/web/app/routes/mirrors/route.tsx
@@ -5,6 +5,7 @@ import {
   useLoaderData,
   useMatches,
   useNavigate,
+  useSearchParams,
 } from '@remix-run/react';
 import differenceInHours from 'date-fns/differenceInHours';
 import format from 'date-fns/format';
@@ -22,13 +23,23 @@ import {
   YAxis,
 } from 'recharts';
 import cn from 'classnames';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 
 export const loader = async ({ request }: LoaderArgs) => {
   const url = new URL(request.url);
   const limit = url.searchParams.get('limit') ?? 50;
+  const tags = url.searchParams.getAll('tag');
+
+  const divergencesParams = new URLSearchParams({
+    limit: String(limit),
+    divergent: 'true',
+  });
+  for (const tag of tags) {
+    divergencesParams.append('tag', tag);
+  }
 
   const divergences = await fetch(
-    `https://request-mirroring-api.nelnetvelocity.workers.dev/mirrors?divergent&limit=${limit}`,
+    `https://request-mirroring-api.nelnetvelocity.workers.dev/mirrors?${divergencesParams}`,
     {
       headers: {
         authorization: 'Bearer scurvy-reuse-bulldozer',
@@ -42,6 +53,7 @@ export const loader = async ({ request }: LoaderArgs) => {
             id: string;
             divergent: boolean;
             created_at: string;
+            tags: Record<string, string> | null;
             control: {
               url: string;
               status: number;
@@ -60,17 +72,26 @@ export const loader = async ({ request }: LoaderArgs) => {
     )
     .then((resp) => resp.data);
 
-  const lookback = divergences
-    ? differenceInHours(
-        new Date(),
-        parseISO(divergences[divergences.length - 1].created_at),
-      ) + 1
-    : 4;
+  const lookback =
+    divergences && divergences.length > 0
+      ? differenceInHours(
+          new Date(),
+          parseISO(divergences[divergences.length - 1].created_at),
+        ) + 1
+      : 4;
+
+  const aggregationParams = new URLSearchParams({
+    lookbackPeriodHours: String(lookback),
+    rollupPeriodMinutes: '1',
+  });
+  for (const tag of tags) {
+    aggregationParams.append('tag', tag);
+  }
 
   return defer({
     divergences,
     aggregation: fetch(
-      `https://request-mirroring-api.nelnetvelocity.workers.dev/mirrors/aggregation?lookbackPeriodHours=${lookback}&rollupPeriodMinutes=1`,
+      `https://request-mirroring-api.nelnetvelocity.workers.dev/mirrors/aggregation?${aggregationParams}`,
       {
         headers: {
           authorization: 'Bearer scurvy-reuse-bulldozer',
@@ -103,6 +124,95 @@ const getStatusCodeBadge = (statusCode: number) => {
         </span>
       );
   }
+};
+
+// Copied from https://stackoverflow.com/a/16348977
+const stringToColor = (str: string) => {
+  let hash = 0;
+  str.split('').forEach((char) => {
+    hash = char.charCodeAt(0) + ((hash << 5) - hash);
+  });
+  let colour = '#';
+  for (let i = 0; i < 3; i++) {
+    const value = (hash >> (i * 8)) & 0xff;
+    colour += value.toString(16).padStart(2, '0');
+  }
+  return colour;
+};
+
+const Tag = ({
+  tag,
+  onRemove,
+}: {
+  tag: string;
+  onRemove?: (tag: string) => void;
+}) => (
+  <div
+    key={tag}
+    className="ml-2 inline-block badge badge"
+    style={{
+      borderColor: stringToColor(tag),
+      backgroundColor: stringToColor(tag),
+      mixBlendMode: 'difference',
+      color: 'white',
+    }}
+  >
+    {tag}
+    {onRemove && (
+      <XMarkIcon className="h-4 inline" onClick={() => onRemove(tag)} />
+    )}
+  </div>
+);
+
+const TagSelector = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [txt, setTxt] = useState('');
+  const [tags, setTags] = useState(
+    Array.from(searchParams.entries()).map(([_, value]) => value),
+  );
+  useEffect(() => {
+    setSearchParams(new URLSearchParams(tags.map((val) => ['tag', val])));
+  }, [tags, setSearchParams, setTxt]);
+  const [error, setError] = useState(undefined as string | undefined);
+
+  const handleRemove = (tag: string) => {
+    setTags(tags.filter((val) => val !== tag));
+  };
+
+  const handleButtonClick = () => {
+    if (!/^([a-z0-9]+:[a-z0-9]+)$/i.test(txt)) {
+      setError(`Invalid tag format: '${txt}'. Expected 'tag:value'.`);
+      return;
+    }
+
+    setTags([...tags, txt]);
+    setTxt('');
+  };
+
+  return (
+    <div className="mb-8">
+      <div className="form-control w-full max-w-s">
+        <input
+          className={cn('input input-bordered w-full max-w-xs', {
+            'input-error': !!error,
+          })}
+          type="text"
+          placeholder="key:value"
+          value={txt}
+          onChange={(e) => setTxt(e.target.value)}
+          onKeyUp={(e) => (e.key === 'Enter' ? handleButtonClick() : undefined)}
+        />
+        {error && (
+          <label className="label">
+            <span className="label-text-alt text-error">{error}</span>
+          </label>
+        )}
+      </div>
+      {tags.map((tag) => (
+        <Tag key={tag} tag={tag} onRemove={handleRemove} />
+      ))}
+    </div>
+  );
 };
 
 export default function MirrorsList() {
@@ -141,6 +251,7 @@ export default function MirrorsList() {
         className="drawer-toggle"
       />
       <div className="drawer-content py-8 mx-4 md:mx-8">
+        <TagSelector />
         <div className="mb-8">
           <Suspense
             fallback={
@@ -274,9 +385,11 @@ export default function MirrorsList() {
                       <td>
                         {new URL(req.control.url).pathname}
                         {getStatusCodeBadge(req.control.status)}
-                        <div className="ml-2 inline-block badge badge-sm badge-outline badge-info">
-                          {new URL(req.control.url).hostname.split('.')[0]}
-                        </div>
+                        {Object.entries(req.tags ?? {})
+                          .map(([key, value]) => `${key}:${value}`)
+                          .map((tag) => (
+                            <Tag key={tag} tag={tag} />
+                          ))}
                       </td>
                       <td>
                         {new URL(req.shadow.url).pathname}


### PR DESCRIPTION
Adds a "tags" concept to the shadowing services.

Tags added to a shadowing configuration will be attached to each stored request. There is then a simple text box added to the UI where you can specify `tag:value` pairs to filter by.

The primary example I was working with was an `env` tag that could be set to `development`, `qa`, etc so you could filter the page with `env:qa` to see only requests from the QA environment.